### PR TITLE
Remove deprecated terraform codes with using terraform 0.12upgrade command

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -1,15 +1,24 @@
-variable "owner" { description = "Owner name of resources" }
+variable "owner" {
+  description = "Owner name of resources"
+}
+
 variable "site_id" {
   default = "dev"
 }
+
 variable "aws_profile" {
   default = "dev"
 }
+
 variable "aws_region" {
   default = "ap-northeast-1"
 }
+
 provider "aws" {
-  profile = "${var.aws_profile}"
-  region  = "${var.aws_region}"
+  profile = var.aws_profile
+  region  = var.aws_region
 }
-data "aws_caller_identity" "current" {}
+
+data "aws_caller_identity" "current" {
+}
+

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -18,7 +18,7 @@ locals {
       alarm_evaluation_periods  = "1"
       alarm_threshold           = "5"
       alarm_description         = "Warn occurred greater than or equal to 5 time within a minute"
-    }
+    },
   ]
 }
 
@@ -27,39 +27,40 @@ resource "aws_cloudwatch_log_group" "fargate_redash" {
   retention_in_days = 30
 
   tags = {
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "fargate_redash" {
-  count = "${length(local.metrics)}"
+  count = length(local.metrics)
 
-  name           = "${local.metrics.*.filter_name[count.index]}"
-  pattern        = "${local.metrics.*.filter_pattern[count.index]}"
-  log_group_name = "${aws_cloudwatch_log_group.fargate_redash.name}"
+  name           = local.metrics.*.filter_name[count.index]
+  pattern        = local.metrics.*.filter_pattern[count.index]
+  log_group_name = aws_cloudwatch_log_group.fargate_redash.name
 
   metric_transformation {
-    name          = "${local.metrics.*.metric_name[count.index]}"
-    namespace     = "${local.metric_namespace}"
+    name          = local.metrics.*.metric_name[count.index]
+    namespace     = local.metric_namespace
     value         = "1"
     default_value = "0"
   }
 }
-resource "aws_cloudwatch_metric_alarm" "fargate_redash" {
-  count = "${length(local.metrics)}"
 
-  alarm_name          = "${local.metrics.*.metric_name[count.index]}"
-  comparison_operator = "${local.metrics.*.alarm_comparison_operator[count.index]}"
-  evaluation_periods  = "${local.metrics.*.alarm_evaluation_periods[count.index]}"
-  metric_name         = "${local.metrics.*.metric_name[count.index]}"
-  namespace           = "${local.metric_namespace}"
+resource "aws_cloudwatch_metric_alarm" "fargate_redash" {
+  count = length(local.metrics)
+
+  alarm_name          = local.metrics.*.metric_name[count.index]
+  comparison_operator = local.metrics.*.alarm_comparison_operator[count.index]
+  evaluation_periods  = local.metrics.*.alarm_evaluation_periods[count.index]
+  metric_name         = local.metrics.*.metric_name[count.index]
+  namespace           = local.metric_namespace
   period              = "60" # 1 min
   statistic           = "Sum"
-  threshold           = "${local.metrics.*.alarm_threshold[count.index]}"
-  alarm_description   = "${local.metrics.*.alarm_description[count.index]}"
-  alarm_actions       = ["${aws_sns_topic.fargate_redash.arn}"]
+  threshold           = local.metrics.*.alarm_threshold[count.index]
+  alarm_description   = local.metrics.*.alarm_description[count.index]
+  alarm_actions       = [aws_sns_topic.fargate_redash.arn]
   tags = {
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
 

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,40 +1,45 @@
-output "aws_security_group_fargate_redash_id" { value = "${aws_security_group.fargate_redash.id}" }
+output "aws_security_group_fargate_redash_id" {
+  value = aws_security_group.fargate_redash.id
+}
 
 resource "aws_ecs_cluster" "fargate" {
   name = "${var.site_id}-fargate"
 
   tags = {
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
 
 resource "aws_security_group" "fargate_redash" {
   name        = "${var.site_id}-fargate-redash"
   description = "Security group for Redash on Fargate"
-  vpc_id      = "${aws_vpc.main.id}"
+  vpc_id      = aws_vpc.main.id
 
   tags = {
     Name  = "${var.site_id}-fargate-redash"
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
+
 resource "aws_security_group_rule" "fargate_redash_ingress_http" {
   type                     = "ingress"
   from_port                = 5000
   protocol                 = "tcp"
-  security_group_id        = "${aws_security_group.fargate_redash.id}"
-  source_security_group_id = "${aws_security_group.lb_fargate_redash.id}"
+  security_group_id        = aws_security_group.fargate_redash.id
+  source_security_group_id = aws_security_group.lb_fargate_redash.id
   to_port                  = 5000
   description              = "Allow http inbound traffic from load balancer"
 }
+
 resource "aws_security_group_rule" "fargate_redash_egress_all" {
   type = "egress"
   cidr_blocks = [
-    "0.0.0.0/0"
+    "0.0.0.0/0",
   ]
   from_port         = 0
   protocol          = "-1"
-  security_group_id = "${aws_security_group.fargate_redash.id}"
+  security_group_id = aws_security_group.fargate_redash.id
   to_port           = 0
   description       = "Allow all outbound traffic"
 }
+

--- a/terraform/elasticache.tf
+++ b/terraform/elasticache.tf
@@ -1,4 +1,6 @@
-output "aws_elasticache_replication_group_fargate_redis_primary_endpoint_address" { value = "${aws_elasticache_replication_group.fargate_redis.primary_endpoint_address}" }
+output "aws_elasticache_replication_group_fargate_redis_primary_endpoint_address" {
+  value = aws_elasticache_replication_group.fargate_redis.primary_endpoint_address
+}
 
 resource "aws_elasticache_replication_group" "fargate_redis" {
   # "replication_group_id" must contain from 1 to 20 alphanumeric characters or hyphens
@@ -9,24 +11,27 @@ resource "aws_elasticache_replication_group" "fargate_redis" {
   auto_minor_version_upgrade    = true
   engine                        = "redis"
   engine_version                = "5.0.4"
-  parameter_group_name          = "${aws_elasticache_parameter_group.fargate_redis.name}"
+  parameter_group_name          = aws_elasticache_parameter_group.fargate_redis.name
   port                          = 6379
-  subnet_group_name             = "${aws_elasticache_subnet_group.fargate_redis.name}"
+  subnet_group_name             = aws_elasticache_subnet_group.fargate_redis.name
   security_group_ids = [
-    "${aws_security_group.fargate_redis.id}"
+    aws_security_group.fargate_redis.id,
   ]
   maintenance_window = "mon:12:00-mon:13:00"
 
   tags = {
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
+
 resource "aws_elasticache_subnet_group" "fargate_redis" {
   name        = "${var.site_id}-fargate-redis"
   description = "Subnet group of Redis for Fargate"
+
   # subnet_ids  = "${aws_subnet.main_private.*.id}"
-  subnet_ids = "${aws_subnet.main_public.*.id}"
+  subnet_ids = aws_subnet.main_public.*.id
 }
+
 resource "aws_elasticache_parameter_group" "fargate_redis" {
   name        = "${var.site_id}-fargate-redis"
   family      = "redis5.0"
@@ -37,33 +42,37 @@ resource "aws_elasticache_parameter_group" "fargate_redis" {
     value = "3600"
   }
 }
+
 resource "aws_security_group" "fargate_redis" {
   name        = "${var.site_id}-fargate-redis"
   description = "Security group of Redis for Fargate"
-  vpc_id      = "${aws_vpc.main.id}"
+  vpc_id      = aws_vpc.main.id
 
   tags = {
     Name  = "${var.site_id}-fargate-redis"
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
+
 resource "aws_security_group_rule" "fargate_redis_ingress_fargate_redash" {
   type                     = "ingress"
   from_port                = 6379
   protocol                 = "tcp"
-  security_group_id        = "${aws_security_group.fargate_redis.id}"
-  source_security_group_id = "${aws_security_group.fargate_redash.id}"
+  security_group_id        = aws_security_group.fargate_redis.id
+  source_security_group_id = aws_security_group.fargate_redash.id
   to_port                  = 6379
   description              = "Allow redis inbound traffic from Redash on Fargate"
 }
+
 resource "aws_security_group_rule" "fargate_redis_ingress_office" {
   type = "ingress"
   cidr_blocks = [
-    "${var.cidr_office}"
+    var.cidr_office,
   ]
   from_port         = 6379
   protocol          = "tcp"
-  security_group_id = "${aws_security_group.fargate_redis.id}"
+  security_group_id = aws_security_group.fargate_redis.id
   to_port           = 6379
   description       = "Allow redis inbound traffic from my office"
 }
+

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,9 +1,12 @@
-output "aws_iam_role_fargate_redash_arn" { value = "${aws_iam_role.fargate_redash.arn}" }
+output "aws_iam_role_fargate_redash_arn" {
+  value = aws_iam_role.fargate_redash.arn
+}
 
 resource "aws_iam_role" "fargate_redash" {
   name               = "${var.site_id}-fargate-redash"
-  assume_role_policy = "${data.aws_iam_policy_document.fargate_task_assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.fargate_task_assume_role.json
 }
+
 data "aws_iam_policy_document" "fargate_task_assume_role" {
   # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_IAM_role.html
   statement {
@@ -14,8 +17,10 @@ data "aws_iam_policy_document" "fargate_task_assume_role" {
     }
   }
 }
+
 resource "aws_iam_role_policy_attachment" "fargate_redash" {
   # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
-  role       = "${aws_iam_role.fargate_redash.id}"
+  role       = aws_iam_role.fargate_redash.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
+

--- a/terraform/postgresql/iam.tf
+++ b/terraform/postgresql/iam.tf
@@ -4,12 +4,14 @@ data "aws_iam_role" "fargate_redash" {
 
 resource "aws_iam_role_policy" "fargate_redash_secrets_manager" {
   name   = "${data.aws_iam_role.fargate_redash.name}-secrets-manager"
-  policy = "${data.aws_iam_policy_document.fargate_redash_secrets_manager.json}"
-  role   = "${data.aws_iam_role.fargate_redash.id}"
+  policy = data.aws_iam_policy_document.fargate_redash_secrets_manager.json
+  role   = data.aws_iam_role.fargate_redash.id
 }
+
 data "aws_iam_policy_document" "fargate_redash_secrets_manager" {
   statement {
     actions   = ["secretsmanager:GetSecretValue"]
-    resources = "${aws_secretsmanager_secret.fargate_redash.*.arn}"
+    resources = aws_secretsmanager_secret.fargate_redash.*.arn
   }
 }
+

--- a/terraform/postgresql/postgresql.tf
+++ b/terraform/postgresql/postgresql.tf
@@ -1,15 +1,17 @@
-output "postgresql_role_redash_password" { value = "${postgresql_role.redash.password}" }
+output "postgresql_role_redash_password" {
+  value = postgresql_role.redash.password
+}
 
 data "aws_db_instance" "fargate_pg" {
   db_instance_identifier = "${var.site_id}-fargate-pg"
 }
 
 provider "postgresql" {
-  host            = "${data.aws_db_instance.fargate_pg.address}"
+  host            = data.aws_db_instance.fargate_pg.address
   port            = 5432
   database        = "postgres"
   username        = "root"
-  password        = "${var.db_root_password}"
+  password        = var.db_root_password
   superuser       = false
   sslmode         = "require"
   connect_timeout = 15
@@ -19,22 +21,25 @@ resource "random_string" "role_redash_password" {
   length  = 32
   special = false
 }
+
 resource "postgresql_role" "redash" {
   name     = "redash"
   login    = true
-  password = "${random_string.role_redash_password.result}"
+  password = random_string.role_redash_password.result
 }
+
 resource "postgresql_database" "database_redash" {
   name              = "redash"
-  owner             = "${postgresql_role.redash.name}"
+  owner             = postgresql_role.redash.name
   allow_connections = true
   lc_collate        = "DEFAULT"
   lc_ctype          = "DEFAULT"
 
   lifecycle {
     ignore_changes = [
-      "lc_collate",
-      "lc_ctype"
+      lc_collate,
+      lc_ctype,
     ]
   }
 }
+

--- a/terraform/postgresql/variables.tf
+++ b/terraform/postgresql/variables.tf
@@ -1,1 +1,4 @@
-variable "db_root_password" { description = "RDS root password" }
+variable "db_root_password" {
+  description = "RDS root password"
+}
+

--- a/terraform/postgresql/versions.tf
+++ b/terraform/postgresql/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,5 +1,10 @@
-output "aws_db_instance_fargate_pg_address" { value = "${aws_db_instance.fargate_pg.address}" }
-output "aws_db_instance_fargate_pg_password" { value = "${aws_db_instance.fargate_pg.password}" }
+output "aws_db_instance_fargate_pg_address" {
+  value = aws_db_instance.fargate_pg.address
+}
+
+output "aws_db_instance_fargate_pg_password" {
+  value = aws_db_instance.fargate_pg.password
+}
 
 resource "random_string" "fargate_pg_password" {
   length  = 32
@@ -13,7 +18,7 @@ resource "aws_db_instance" "fargate_pg" {
   availability_zone          = "${var.aws_region}${local.vpc_az[0]}"
   backup_retention_period    = 7
   backup_window              = "00:05-00:35"
-  db_subnet_group_name       = "${aws_db_subnet_group.fargate_pg.name}"
+  db_subnet_group_name       = aws_db_subnet_group.fargate_pg.name
   engine                     = "postgres"
   engine_version             = "11.2"
   final_snapshot_identifier  = "${var.site_id}-fargate-pg-final"
@@ -21,29 +26,32 @@ resource "aws_db_instance" "fargate_pg" {
   instance_class             = "db.t2.micro"
   maintenance_window         = "mon:12:00-mon:12:30"
   multi_az                   = false
-  parameter_group_name       = "${aws_db_parameter_group.fargate_pg.name}"
-  password                   = "${random_string.fargate_pg_password.result}"
+  parameter_group_name       = aws_db_parameter_group.fargate_pg.name
+  password                   = random_string.fargate_pg_password.result
   port                       = 5432
   publicly_accessible        = true
   storage_type               = "gp2"
   username                   = "root"
   vpc_security_group_ids = [
-    "${aws_security_group.fargate_pg.id}"
+    aws_security_group.fargate_pg.id,
   ]
 
   tags = {
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
+
 resource "aws_db_subnet_group" "fargate_pg" {
   name = "${var.site_id}-fargate-pg"
+
   # subnet_ids = "${aws_subnet.main_private.*.id}"
-  subnet_ids = "${aws_subnet.main_public.*.id}"
+  subnet_ids = aws_subnet.main_public.*.id
 
   tags = {
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
+
 resource "aws_db_parameter_group" "fargate_pg" {
   name   = "${var.site_id}-faragate-pg"
   family = "postgres11"
@@ -58,37 +66,40 @@ resource "aws_db_parameter_group" "fargate_pg" {
   }
 
   tags = {
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
 
 resource "aws_security_group" "fargate_pg" {
   name        = "${var.site_id}-fargate-pg"
   description = "Security group for Fargate database"
-  vpc_id      = "${aws_vpc.main.id}"
+  vpc_id      = aws_vpc.main.id
 
   tags = {
     Name  = "${var.site_id}-fargate-pg"
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
+
 resource "aws_security_group_rule" "fargate_pg_ingress_fargate_redash" {
   type                     = "ingress"
   from_port                = 5432
   protocol                 = "tcp"
-  security_group_id        = "${aws_security_group.fargate_pg.id}"
-  source_security_group_id = "${aws_security_group.fargate_redash.id}"
+  security_group_id        = aws_security_group.fargate_pg.id
+  source_security_group_id = aws_security_group.fargate_redash.id
   to_port                  = 5432
   description              = "Allow postgres inbound traffic from Redash on Fargate"
 }
+
 resource "aws_security_group_rule" "fargate_pg_ingress_office" {
   type = "ingress"
   cidr_blocks = [
-    "${var.cidr_office}"
+    var.cidr_office,
   ]
   from_port         = 5432
   protocol          = "tcp"
-  security_group_id = "${aws_security_group.fargate_pg.id}"
+  security_group_id = aws_security_group.fargate_pg.id
   to_port           = 5432
   description       = "Allow postgres inbound traffic from my office"
 }
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,12 +1,17 @@
-variable "cidr_office" { description = "CIDR allowed connecting to resources, like your office's IP" }
-variable "s3_bucket_name" { description = "Your S3 bucket name" }
+variable "cidr_office" {
+  description = "CIDR allowed connecting to resources, like your office's IP"
+}
+
+variable "s3_bucket_name" {
+  description = "Your S3 bucket name"
+}
 
 locals {
   vpc_cidr_block = "10.1.0.0/21"
   vpc_az = [
     "a",
     "c",
-    "d"
+    "d",
   ]
   vpc_subnet_public_cidr_blocks = {
     "a" = "10.1.0.0/24"
@@ -19,3 +24,4 @@ locals {
     "d" = "10.1.5.0/24"
   }
 }
+

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,98 +1,119 @@
-output "aws_subnet_main_public_id_0" { value = "${aws_subnet.main_public.0.id}" }
-output "aws_subnet_main_public_id_1" { value = "${aws_subnet.main_public.1.id}" }
-output "aws_subnet_main_public_id_2" { value = "${aws_subnet.main_public.2.id}" }
-output "aws_subnet_main_private_id_0" { value = "${aws_subnet.main_private.0.id}" }
-output "aws_subnet_main_private_id_1" { value = "${aws_subnet.main_private.1.id}" }
-output "aws_subnet_main_private_id_2" { value = "${aws_subnet.main_private.2.id}" }
+output "aws_subnet_main_public_id_0" {
+  value = aws_subnet.main_public[0].id
+}
+
+output "aws_subnet_main_public_id_1" {
+  value = aws_subnet.main_public[1].id
+}
+
+output "aws_subnet_main_public_id_2" {
+  value = aws_subnet.main_public[2].id
+}
+
+output "aws_subnet_main_private_id_0" {
+  value = aws_subnet.main_private[0].id
+}
+
+output "aws_subnet_main_private_id_1" {
+  value = aws_subnet.main_private[1].id
+}
+
+output "aws_subnet_main_private_id_2" {
+  value = aws_subnet.main_private[2].id
+}
 
 resource "aws_vpc" "main" {
-  cidr_block           = "${local.vpc_cidr_block}"
+  cidr_block           = local.vpc_cidr_block
   enable_dns_support   = true
   enable_dns_hostnames = true
   enable_classiclink   = false
 
   tags = {
     Name  = "${var.site_id}-main"
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
 
 resource "aws_subnet" "main_public" {
-  count = "${length(local.vpc_az)}"
+  count = length(local.vpc_az)
 
   availability_zone       = "${var.aws_region}${local.vpc_az[count.index]}"
-  cidr_block              = "${lookup(local.vpc_subnet_public_cidr_blocks, local.vpc_az[count.index])}"
+  cidr_block              = local.vpc_subnet_public_cidr_blocks[local.vpc_az[count.index]]
   map_public_ip_on_launch = true
-  vpc_id                  = "${aws_vpc.main.id}"
+  vpc_id                  = aws_vpc.main.id
 
   tags = {
     Name  = "${var.site_id}-main-public-${local.vpc_az[count.index]}"
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
+
 resource "aws_internet_gateway" "main" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 
   tags = {
-    Owner = "${var.owner}"
+    Owner = var.owner
     Name  = "${var.site_id}-main"
   }
 }
+
 resource "aws_route" "main" {
-  route_table_id         = "${aws_vpc.main.main_route_table_id}"
+  route_table_id         = aws_vpc.main.main_route_table_id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.main.id}"
+  gateway_id             = aws_internet_gateway.main.id
 }
 
 resource "aws_subnet" "main_private" {
-  count = "${length(local.vpc_az)}"
+  count = length(local.vpc_az)
 
   availability_zone       = "${var.aws_region}${local.vpc_az[count.index]}"
-  cidr_block              = "${lookup(local.vpc_subnet_private_cidr_blocks, local.vpc_az[count.index])}"
+  cidr_block              = local.vpc_subnet_private_cidr_blocks[local.vpc_az[count.index]]
   map_public_ip_on_launch = false
-  vpc_id                  = "${aws_vpc.main.id}"
+  vpc_id                  = aws_vpc.main.id
 
   tags = {
     Name  = "${var.site_id}-main-private-${local.vpc_az[count.index]}"
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
-resource "aws_route_table" "main_private" {
-  count = "${length(local.vpc_az)}"
 
-  vpc_id = "${aws_vpc.main.id}"
+resource "aws_route_table" "main_private" {
+  count = length(local.vpc_az)
+
+  vpc_id = aws_vpc.main.id
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = "${aws_nat_gateway.main_public.*.id[count.index]}"
+    nat_gateway_id = aws_nat_gateway.main_public[count.index].id
   }
 }
-resource "aws_route_table_association" "main_private" {
-  count = "${length(local.vpc_az)}"
 
-  subnet_id      = "${aws_subnet.main_private.*.id[count.index]}"
-  route_table_id = "${aws_route_table.main_private.*.id[count.index]}"
+resource "aws_route_table_association" "main_private" {
+  count = length(local.vpc_az)
+
+  subnet_id      = aws_subnet.main_private[count.index].id
+  route_table_id = aws_route_table.main_private[count.index].id
 }
 
 resource "aws_nat_gateway" "main_public" {
-  count = "${length(local.vpc_az)}"
+  count = length(local.vpc_az)
 
-  allocation_id = "${aws_eip.main_public_nat_gw.*.id[count.index]}"
-  subnet_id     = "${aws_subnet.main_public.*.id[count.index]}"
+  allocation_id = aws_eip.main_public_nat_gw[count.index].id
+  subnet_id     = aws_subnet.main_public[count.index].id
 
   tags = {
     Name  = "${var.site_id}-main-public-${local.vpc_az[count.index]}"
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
-  depends_on = [
-    "aws_internet_gateway.main"
-  ]
+  depends_on = [aws_internet_gateway.main]
 }
+
 resource "aws_eip" "main_public_nat_gw" {
-  count = "${length(local.vpc_az)}"
+  count = length(local.vpc_az)
 
   vpc = true
   tags = {
     Name  = "${var.site_id}-main-public-nat-gw-${local.vpc_az[count.index]}"
-    Owner = "${var.owner}"
+    Owner = var.owner
   }
 }
+


### PR DESCRIPTION
This pull request will remove deprecated terraform codes with using `terraform 0.12upgrade` command.

The deprecated terraform codes mainly consist of [Interpolation-only expressions](https://discuss.hashicorp.com/t/terraform-0-12-14-released/3898).